### PR TITLE
Tweak the styling for the page header

### DIFF
--- a/app/assets/stylesheets/components-vue/_topbar.scss
+++ b/app/assets/stylesheets/components-vue/_topbar.scss
@@ -4,7 +4,7 @@
 .topbar {
   background-color: $black-translucent;
   color: white;
-  padding: rem-calc(14);
+  padding: rem-calc(17 20 16 20);
   width: 100%;
 
   display: flex;

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -9,7 +9,23 @@
   display: flex;
 
   &__title {
-    background-color: $black-translucent;
-    padding: rem-calc(14 38 20 0);
+    h1 {
+      padding: rem-calc(24 45 30 160);
+
+      display: inline-block;
+      position: relative;
+      z-index: 0;
+
+      &:before {
+        background-color: $black-translucent;
+        content: '';
+        width: rem-calc(2000); height: 100%;
+        
+        position: absolute;
+        top: 0;
+        right: 0;
+        z-index: -1;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -9,6 +9,9 @@
   display: flex;
 
   &__title {
+    margin-top: rem-calc(77); //match the height of the topbar
+    margin-right: rem-calc(160);
+
     h1 {
       padding: rem-calc(24 45 30 160);
 

--- a/app/assets/stylesheets/utilities/_base.scss
+++ b/app/assets/stylesheets/utilities/_base.scss
@@ -12,8 +12,8 @@ body {
 
   h1 {
     color: white;
-    font-size: rem-calc(60);
-    font-style: italic;
+    font-size: rem-calc(48);
+    line-height: 1.2;
     margin: 0;
   }
 }

--- a/app/assets/stylesheets/utilities/_base.scss
+++ b/app/assets/stylesheets/utilities/_base.scss
@@ -13,7 +13,6 @@ body {
   h1 {
     color: white;
     font-size: rem-calc(48);
-    line-height: 1.2;
     margin: 0;
   }
 }

--- a/app/javascript/components/table/Row.vue
+++ b/app/javascript/components/table/Row.vue
@@ -60,8 +60,7 @@
 
   export default {
     name: "row",
-    props: {
-      index: {
+    props: {      index: {
         required: true
       },
       item: { 

--- a/app/javascript/components/table/Row.vue
+++ b/app/javascript/components/table/Row.vue
@@ -17,7 +17,7 @@
       </td>
     </tr>
     <tr class="table__row--expandable flex" :class="{ 'table__row--open' : isOpen }">
-      
+
       <div class="flex-2-fiths">
         <h3>Resource</h3>
         {{ item.resource }}
@@ -45,7 +45,7 @@
               <span class="table__theme-title">{{ themeName('environmental_impact_assessment') }}</span>
             </li>
             <li v-if="item.ecosystem_services" class="table__theme">
-              <span class="icon--round icon--theme icon--theme-5">ES</span> 
+              <span class="icon--round icon--theme icon--theme-5">ES</span>
               <span class="table__theme-title">{{ themeName('ecosystem_services') }}</span>
             </li>
           </ul>
@@ -60,10 +60,11 @@
 
   export default {
     name: "row",
-    props: {      index: {
+    props: {
+      index: {
         required: true
       },
-      item: { 
+      item: {
         type: Object,
         required: true
       }
@@ -126,8 +127,8 @@
 
       transition: max-height .3s ease-in-out;
     }
-    
-    &--open { 
+
+    &--open {
       max-height: rem-calc(212);
     }
   }

--- a/app/views/global/_header.html.erb
+++ b/app/views/global/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="header">
-  <div class="header__title">
+  <div class="header__title container">
     <h1><%= title %></h1>
   </div>
 </header>


### PR DESCRIPTION
Add hack to make the transparent background behind the h1 bleed off the side of the page.
Complete styling of header to match the design.

Logo missing.
Hero image missing.