### PR TITLE
Generate array of thematic areas

### DIFF
--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -53,7 +53,26 @@ class Metadata < ApplicationRecord
   end
 
   def self.metadata_to_json
-    Metadata.all.order(id: :asc).to_json
+    output = []
+    metadata = Metadata.all.order(id: :asc)
+    metadata.to_a.each do |meta|
+      meta_attributes = meta.attributes
+      meta_attributes[:themes] = []
+      meta_attributes[:themes] << "marine_spatial_planning" if meta_attributes["marine_spatial_planning"]
+      meta_attributes[:themes] << "education" if meta_attributes["education"]
+      meta_attributes[:themes] << "environmental_impact_assessment" if meta_attributes["environmental_impact_assessment"]
+      meta_attributes[:themes] << "ecosystem_assessment" if meta_attributes["ecosystem_assessment"]
+      meta_attributes[:themes] << "ecosystem_services" if meta_attributes["ecosystem_services"]
+      meta_attributes.delete("created_at")
+      meta_attributes.delete("updated_at")
+      meta_attributes.delete("marine_spatial_planning")
+      meta_attributes.delete("education")
+      meta_attributes.delete("environmental_impact_assessment")
+      meta_attributes.delete("ecosystem_assessment")
+      meta_attributes.delete("ecosystem_services")
+      output << meta_attributes
+    end
+    output.to_json
   end
 
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -58,18 +58,13 @@ class Metadata < ApplicationRecord
     metadata.to_a.each do |meta|
       meta_attributes = meta.attributes
       meta_attributes[:themes] = []
-      meta_attributes[:themes] << "marine_spatial_planning" if meta_attributes["marine_spatial_planning"]
-      meta_attributes[:themes] << "education" if meta_attributes["education"]
-      meta_attributes[:themes] << "environmental_impact_assessment" if meta_attributes["environmental_impact_assessment"]
-      meta_attributes[:themes] << "ecosystem_assessment" if meta_attributes["ecosystem_assessment"]
-      meta_attributes[:themes] << "ecosystem_services" if meta_attributes["ecosystem_services"]
+      ["marine_spatial_planning", "education", "environmental_impact_assessment",
+      "ecosystem_assessment", "ecosystem_services"].each do |attribute|
+        meta_attributes[:themes] << attribute if meta_attributes[attribute]
+        meta_attributes.delete(attribute)
+      end
       meta_attributes.delete("created_at")
       meta_attributes.delete("updated_at")
-      meta_attributes.delete("marine_spatial_planning")
-      meta_attributes.delete("education")
-      meta_attributes.delete("environmental_impact_assessment")
-      meta_attributes.delete("ecosystem_assessment")
-      meta_attributes.delete("ecosystem_services")
       output << meta_attributes
     end
     output.to_json

--- a/db/migrate/20171206170307_metadata_factsheet_can_be_nil.rb
+++ b/db/migrate/20171206170307_metadata_factsheet_can_be_nil.rb
@@ -1,0 +1,5 @@
+class MetadataFactsheetCanBeNil < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :metadata, :factsheet, true
+  end
+end

--- a/db/migrate/20171206170627_change_metadata_to_boolean.rb
+++ b/db/migrate/20171206170627_change_metadata_to_boolean.rb
@@ -1,0 +1,5 @@
+class ChangeMetadataToBoolean < ActiveRecord::Migration[5.1]
+  def change
+    change_column :metadata, :metadata, 'boolean USING CAST(metadata AS boolean)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171204104811) do
+ActiveRecord::Schema.define(version: 20171206170627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,8 +22,8 @@ ActiveRecord::Schema.define(version: 20171204104811) do
     t.string "contact_organisation"
     t.string "dataset_id"
     t.string "website_download_link"
-    t.string "metadata", null: false
-    t.string "factsheet", null: false
+    t.boolean "metadata", null: false
+    t.string "factsheet"
     t.boolean "marine_spatial_planning", null: false
     t.boolean "education", null: false
     t.boolean "environmental_impact_assessment", null: false

--- a/lib/tasks/import_metadata.rake
+++ b/lib/tasks/import_metadata.rake
@@ -35,7 +35,13 @@ namespace :import do
       metadata_row_hash = {}
 
       metadata_hash.keys.each do |key|
-        metadata_row_hash[key] = csv_metadata_row[metadata_hash[key]]&.strip || "Empty"
+        if key == :metadata
+          metadata_row_hash[key] = csv_metadata_row[metadata_hash[key]]&.strip || false
+        elsif key == :factsheet
+          metadata_row_hash[key] = csv_metadata_row[metadata_hash[key]]&.strip || nil
+        else
+          metadata_row_hash[key] = csv_metadata_row[metadata_hash[key]]&.strip || "Empty"
+        end
       end
 
       current_dataset_id = csv_metadata_row[metadata_hash[:dataset_id]]


### PR DESCRIPTION
Adjustments have been made to the following;

- The metadata JSON is now different in the sense that we return an array with the various thematic areas, rather than a true or false for each kind of thematic area,

- `factsheet` can be nil,

- `metadata` is now a boolean,

- Adjustments have been made to the rake import metadata task according to all of these changes.