### PR TITLE
Initial support for csv export for metadata

### DIFF
--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -3,4 +3,12 @@ class MetadataController < ApplicationController
     @filters = Metadata.filters_to_json
     @metadata = Metadata.metadata_to_json
   end
+
+  def download
+    send_data Metadata.to_csv, {
+              type: "text/csv; charset=iso-8859-1; header=present",
+              disposition: "attachment",
+              filename: "marine-data-manual-#{Date.today}.csv" }
+
+  end
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -58,4 +58,33 @@ class Metadata < ApplicationRecord
     Metadata.all.order(id: :asc).to_json
   end
 
+  def self.to_csv
+    csv = ''
+    metadata_columns = Metadata.new.attributes.keys
+    metadata_columns.delete("created_at")
+    metadata_columns.delete("updated_at")
+
+    metadata_columns.map! { |e|
+      e.gsub("_", " ").capitalize
+    }
+
+    csv << metadata_columns.join(',')
+    csv << "\r\n"
+
+    metadata = Metadata.order(id: :asc)
+
+    metadata.to_a.each do |meta|
+      metadata_attributes = meta.attributes
+      metadata_attributes.delete("created_at")
+      metadata_attributes.delete("updated_at")
+
+      metadata_attributes = metadata_attributes.values.map{ |e| "\"#{e}\"" }
+      csv << metadata_attributes.join(',').to_s
+      csv << "\r\n"
+    end
+
+    csv
+
+  end
+
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -69,7 +69,7 @@ class Metadata < ApplicationRecord
     }
 
     csv << metadata_columns.join(',')
-    csv << "\r\n"
+    csv << "\n"
 
     metadata = Metadata.order(id: :asc)
 
@@ -80,7 +80,7 @@ class Metadata < ApplicationRecord
 
       metadata_attributes = metadata_attributes.values.map{ |e| "\"#{e}\"" }
       csv << metadata_attributes.join(',').to_s
-      csv << "\r\n"
+      csv << "\n"
     end
 
     csv

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
   get 'environmental-impact-assessment', to: 'environmental_impact_assessment#index'
   get 'ecosystem-assessment', to: 'ecosystem_assessment#index'
   get 'ecosystem-services', to: 'ecosystem_services#index'
+  get '/download', to: 'metadata#download'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,6 @@ Rails.application.routes.draw do
   get 'environmental-impact-assessment', to: 'environmental_impact_assessment#index'
   get 'ecosystem-assessment', to: 'ecosystem_assessment#index'
   get 'ecosystem-services', to: 'ecosystem_services#index'
-  get '/download', to: 'metadata#download'
+  get '/metadata/download', to: 'metadata#download'
 
 end


### PR DESCRIPTION
You can now download a CSV file by going to `/download` in the address bar. Currently there is no button for this, but the download works and has been tested.