### PR TITLE
add ga script to head

### DIFF
--- a/app/javascript/metadata.js
+++ b/app/javascript/metadata.js
@@ -11,9 +11,12 @@ import NavBurger from './components/nav/NavBurger.vue'
 import NavLink from './components/nav/NavLink.vue'
 import Popout from './components/popout/Popout.vue'
 
-Vue.use(VueAnalytics, {
-  id: 'UA-112614361-2'
-})
+if (window._railsEnv === 'production') {
+  Vue.use(VueAnalytics, {
+    id: 'UA-112614361-2',
+    checkDuplicatedScript: true
+  })
+}
 
 // create event hub and export so that it can be imported into .vue files
 export const eventHub = new Vue()

--- a/app/views/global/_google_analytics.html.erb
+++ b/app/views/global/_google_analytics.html.erb
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-112614361-2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-112614361-2');
+</script>

--- a/app/views/global/_head.html.erb
+++ b/app/views/global/_head.html.erb
@@ -32,4 +32,12 @@
 <%= stylesheet_pack_tag 'application' %>
 <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 
+<%= javascript_tag do %>
+  window._railsEnv = "<%= Rails.env %>"
+<% end %>
+
+<% if Rails.env.production? %>
+  <%= render 'global/google_analytics' %>
+<% end %>
+
 <%= javascript_pack_tag 'application' %>


### PR DESCRIPTION
This fixes the issues with analytics - tested on pp-live-report. Vue-analytics will only register users when they complete a tracked event (unless page stuff is set up, but this doesn't seem easy)